### PR TITLE
lets also tag the locally cached docker image with the release versio…

### DIFF
--- a/vars/stageExtraImages.groovy
+++ b/vars/stageExtraImages.groovy
@@ -12,6 +12,7 @@ def call(body) {
         retry (3){
           sh "docker pull docker.io/fabric8/${image}:latest"
           sh "docker tag docker.io/fabric8/${image}:latest ${env.FABRIC8_DOCKER_REGISTRY_SERVICE_HOST}:${env.FABRIC8_DOCKER_REGISTRY_SERVICE_PORT}/fabric8/${image}:${config.tag}"
+          sh "docker tag docker.io/fabric8/${image}:latest docker.io/fabric8/${image}:${config.tag}"
           sh "docker push ${env.FABRIC8_DOCKER_REGISTRY_SERVICE_HOST}:${env.FABRIC8_DOCKER_REGISTRY_SERVICE_PORT}/fabric8/${image}:${config.tag}"
         }
       }


### PR DESCRIPTION
…n so we can avoid a docker push / pull when running on a single node cluster