### PR TITLE
adjust Maven memory limits

### DIFF
--- a/vars/mavenTemplate.groovy
+++ b/vars/mavenTemplate.groovy
@@ -22,13 +22,13 @@ def call(Map parameters = [:], body) {
                         resourceLimitMemory: '512Mi'], // needs to be high to work on OSO
                         [name: 'maven', image: "${mavenImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true, workingDir: '/home/jenkins/',
                          envVars: [
-                                 [key: 'MAVEN_OPTS', value: '-Duser.home=/root/ -XX:+UseParallelGC \
+                                 [key: '_JAVA_OPTIONS', value: '-Duser.home=/root/ -XX:+UseParallelGC \
          -XX:MinHeapFreeRatio=20 \
          -XX:MaxHeapFreeRatio=40 \
          -XX:GCTimeRatio=4 \
          -XX:AdaptiveSizePolicyWeight=90 \
-         -Xms512m -Xmx512m']],
-                         resourceLimitMemory: '768Mi']],
+         -Xmx256m']],
+                         resourceLimitMemory: '1024Mi']],
                 volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
                           persistentVolumeClaim(claimName: 'jenkins-mvn-local-repo', mountPath: '/root/.mvnrepository'),
                           secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),


### PR DESCRIPTION
This commit changes 3 memory settings:

1. Use `_JAVA_OPTIONS` instead of `MAVEN_OPTS`.
2. Lower the max heap from 512Mi to 256Mi.
3. Raise the memory resource limit for the Maven build container
   from 768Mi to 1024Mi.

The reason for 1 is that _all_ Java processes running in the Maven
build container should respect the JVM options, not just Maven.

The reason for 2+3 combined is that typical WildFly Swarm unit test
starts an entire Swarm uberjar, which is a _3rd_ Java process
running in the container (after Maven itself and Surefire runner).
If there are 3 Java processes, each of them limited to `-Xmx256m`,
there needs to be some space for JVM bookkeeping on the native heap.

Raising the memory resource limit of the container to 1024Mi should
work just fine. The JNLP container is limited to 512Mi, which totals
to 1.5Gi, which is comfortably under the memory quota for terminating
containers.