### PR TITLE
feat(node): update the reference to the fabric8-ui-builder image

### DIFF
--- a/vars/fabric8UITemplate.groovy
+++ b/vars/fabric8UITemplate.groovy
@@ -6,7 +6,7 @@ def call(Map parameters = [:], body) {
     def defaultLabel = buildId('ui')
     def label = parameters.get('label', defaultLabel)
 
-    def uiImage = parameters.get('uiImage', 'fabric8/fabric8-ui-builder:0.0.9')
+    def uiImage = parameters.get('uiImage', 'fabric8/fabric8-ui-builder:v3c57d6b')
     def inheritFrom = parameters.get('inheritFrom', 'base')
     def jnlpImage = (flow.isOpenShift()) ? 'fabric8/jenkins-slave-base-centos7:0.0.1' : 'jenkinsci/jnlp-slave:2.62'
 


### PR DESCRIPTION
I'm not sure this is the right reference as it was a version number and is now a sha, but it is what was released on docker hub.