### PR TITLE
don't use JOB_NAME for Kubernetes/OpenShift names

### DIFF
--- a/src/io/fabric8/Utils.groovy
+++ b/src/io/fabric8/Utils.groovy
@@ -571,6 +571,19 @@ def getRepoName(){
   return jobName
 }
 
+
+// helper to get resource name that can be used as an OpenShift and Kubernetes identifier
+def getResourceName(){
+  def name = env.JOB_NAME
+
+  // only lower case alphanumeric. "-" and "." are allowed for Kubernetes name with max lenght of 253
+  name = name.replaceAll("/","-").toLowerCase()
+  name = name.replaceAll(/[^a-z0-9\.-]/,"").take(254)
+
+  return name
+}
+
+
 @NonCPS
 def getOpenShiftBuildName(){
   def activeInstance = Jenkins.getActiveInstance()


### PR DESCRIPTION
Currently `env.JOB_NAME` is used for naming Kubernetes/OpenShift resources.

I run into problems with that as `JOB_NAME` contains `/`. 
On current Fabric8  and OSIO version i got `<github_username>/<repo_name>/<branch>` as `JOB_NAME`

This PR:
 -  adds new function `getResourceName` to `utils` that generates valid resource name from  `env.JOB_NAME`.
 - uses this function everywhere where JOB_NAME was used to define Kubernetes resource name.