### PR TITLE
fix: unblocks integration tests by fixing cube properties

### DIFF
--- a/src/io/fabric8/Utils.groovy
+++ b/src/io/fabric8/Utils.groovy
@@ -113,9 +113,6 @@ boolean isDisabledITests() {
     e.printStackTrace()
   }
 
-  // TODO lets just disable ITests for now until this issue is fixed:
-  echo "Due to this issue: https://github.com/openshiftio/booster-common/issues/8 we are temporary disabling integration tests OOTB"
-  answer = true
   return answer;
 }
 

--- a/vars/mavenIntegrationTest.groovy
+++ b/vars/mavenIntegrationTest.groovy
@@ -29,7 +29,7 @@ def call(body) {
         echo "WARNING: Integration tests are current DISABLED for these pipelines!"
 
     } else {
-        sh "mvn org.apache.maven.plugins:maven-failsafe-plugin:2.18.1:integration-test ${kubeNS} -Dit.test=${config.itestPattern} -DfailIfNoTests=${config.failIfNoTests} org.apache.maven.plugins:maven-failsafe-plugin:2.18.1:verify"
+        sh "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test ${kubeNS} -Dit.test=${config.itestPattern} -DfailIfNoTests=${config.failIfNoTests} org.apache.maven.plugins:maven-failsafe-plugin:verify"
 
         junitResults(body);
     }

--- a/vars/mavenIntegrationTest.groovy
+++ b/vars/mavenIntegrationTest.groovy
@@ -29,7 +29,7 @@ def call(body) {
         echo "WARNING: Integration tests are current DISABLED for these pipelines!"
 
     } else {
-        sh "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test ${kubeNS} -Dit.test=${config.itestPattern} -DfailIfNoTests=${config.failIfNoTests} org.apache.maven.plugins:maven-failsafe-plugin:verify"
+        sh "mvn org.apache.maven.plugins:maven-failsafe-plugin:integration-test ${kubeNS} -P openshift-it -Dit.test=${config.itestPattern} -DfailIfNoTests=${config.failIfNoTests} org.apache.maven.plugins:maven-failsafe-plugin:verify"
 
         junitResults(body);
     }

--- a/vars/mavenIntegrationTest.groovy
+++ b/vars/mavenIntegrationTest.groovy
@@ -16,7 +16,7 @@ def call(body) {
         try {
             def ns = utils.environmentNamespace(envName)
             if (ns) {
-                kubeNS = "-Dkubernetes.namespace=${ns} -Dfabric8.use.existing=${ns}"
+                kubeNS = "-Dnamespace.use.existing=${ns}"
                 echo "Running the integration tests in the namespace: ${ns}"
             }
         } catch (e) {


### PR DESCRIPTION
This fix enables integration tests to be executed during "CI build" (on the PR).

The major issue was using wrong `kubeNS` environment variable to instruct  Arquillian Cube to run IT tests of boosters.

Tested on OpenShift.io both for PR build and `master`:

- [PR](https://github.com/lordofthejars/swarmq/pull/1) and [build log](https://gist.github.com/lordofthejars/396b0b878b0b97e55ac83f7c814f9c59)
- [master build log](https://gist.github.com/lordofthejars/7413cdfdbb4688ef54ebb6a1f584f6ca) - where the deployment step is also shown

Important to emphasize here is that Integration Tests (`IT`s) are only executed during `CI` mode of the pipeline library, so when PR is open. Those tests never ran against `master`.

Fixes https://github.com/openshiftio/openshift.io/issues/2299
Relates to https://github.com/openshiftio/booster-common/issues/8