### PR TITLE
adding secret env for planner team

### DIFF
--- a/vars/fabric8UITemplate.groovy
+++ b/vars/fabric8UITemplate.groovy
@@ -12,6 +12,14 @@ def call(Map parameters = [:], body) {
 
     def cloud = flow.getCloudConfig()
 
+    def userSecret = 'planner-team-test-osio-token'
+
+    def testEnvVars = [
+            secretEnvVar(secretName: userSecret, key: 'PLANNER_TOKEN', secretKey: 'planner-test-osio-token'),
+
+            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
+    ]
+
     def utils = new io.fabric8.Utils()
     // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
     if (utils.isKubernetesPluginVersion013()) {
@@ -31,9 +39,8 @@ def call(Map parameters = [:], body) {
                                     args: 'cat',
                                     ttyEnabled: true,
                                     workingDir: '/home/jenkins/',
-                                    envVars: [
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
-                            )],
+                                    envVars: testEnvVars)
+                    ],
                     volumes: [
                             secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
                             secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
@@ -53,9 +60,7 @@ def call(Map parameters = [:], body) {
                                     privileged: true,
                                     workingDir: '/home/jenkins/',
                                     ttyEnabled: true,
-                                    envVars: [
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
-                                    ])
+                                    envVars: testEnvVars)
                     ],
                     volumes: [
                             secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),


### PR DESCRIPTION
This adds env variable 'TOKEN' which can be used by planner to run the tests 
cc : @jarifibrahim
