### PR TITLE
Get space label from Build object and pass to fabric8-maven-plugin

### DIFF
--- a/src/io/fabric8/Utils.groovy
+++ b/src/io/fabric8/Utils.groovy
@@ -305,6 +305,29 @@ def addAnnotationToBuild(annotation, value) {
 }
 
 @NonCPS
+def getSpaceLabelFromBuild() {
+    def flow = new Fabric8Commands()
+    if (flow.isOpenShift()) {
+        def buildName = getValidOpenShiftBuildName()
+        OpenShiftClient oClient = new DefaultOpenShiftClient()
+        def usersNamespace = getUsersNamespace()
+        echo "looking for ${buildName} in namespace ${usersNamespace}"
+        def labels = oClient.builds().inNamespace(usersNamespace).withName(buildName).get().getMetadata().getLabels()
+        if (labels != null) {
+            spaceLabel = labels.get("space")
+            if (spaceLabel != null) {
+                echo "Found label for space: '${spaceLabel}', in Build ${buildName}"
+                return spaceLabel
+            }
+        }
+        echo "No space label found in Build ${buildName}"
+    } else {
+        echo "Not running on openshift so skip adding annotation ${annotation}: value"
+    }
+    return ""
+}
+
+@NonCPS
 def getUsersNamespace() {
     def usersNamespace = getNamespace()
     if (usersNamespace.endsWith("-jenkins")) {

--- a/src/io/fabric8/Utils.groovy
+++ b/src/io/fabric8/Utils.groovy
@@ -305,13 +305,14 @@ def addAnnotationToBuild(annotation, value) {
 }
 
 @NonCPS
-def getSpaceLabelFromBuild() {
+def getSpaceLabelFromBuild(buildName) {
     def flow = new Fabric8Commands()
     if (flow.isOpenShift()) {
-        def buildName = getValidOpenShiftBuildName()
         OpenShiftClient oClient = new DefaultOpenShiftClient()
         def usersNamespace = getUsersNamespace()
         echo "looking for ${buildName} in namespace ${usersNamespace}"
+
+        // Search for label named 'space' in currently running Build object
         def labels = oClient.builds().inNamespace(usersNamespace).withName(buildName).get().getMetadata().getLabels()
         if (labels != null) {
             spaceLabel = labels.get("space")
@@ -322,7 +323,7 @@ def getSpaceLabelFromBuild() {
         }
         echo "No space label found in Build ${buildName}"
     } else {
-        echo "Not running on openshift so skip adding annotation ${annotation}: value"
+        echo "Not running on OpenShift, so not looking for 'space' label"
     }
     return ""
 }

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -5,7 +5,7 @@ import org.apache.maven.model.Plugin
 import org.apache.maven.model.PluginExecution
 import org.apache.maven.model.Profile
 
-@Field final String FMP_STABLE_VERSION = "3.5.38"
+@Field final String FMP_STABLE_VERSION = "3.5.40"
 
 // First version of FMP to include 'osio' profile. Should not be modified.
 @Field final String FMP_OSIO_PROFILE_MIN_VERSION = "3.5.40"
@@ -200,14 +200,14 @@ def patchPluginBasedOnParent(plugin, parent) {
         return false
     }
 
-    if (parent.artifactId == "booster-parent" && compareVersions(parent.version, "20") < 0) {
-        println "patching maven plugin for booster-parent parent v20"
+    if (parent.artifactId == "booster-parent" && compareVersions(parent.version, "23") < 0) {
+        println "patching maven plugin for booster-parent parent v23"
         plugin.version = FMP_STABLE_VERSION
         return true
     }
 
-    if (parent.artifactId == "spring-boot-booster-parent" && compareVersions(parent.version, "1.5.10-15") < 0) {
-        println "patching maven plugin for spring-boot-booster-parent v1.5.10-15"
+    if (parent.artifactId == "spring-boot-booster-parent") {
+        println "patching maven plugin for spring-boot-booster-parent"
         plugin.version = FMP_STABLE_VERSION
         return true;
     }
@@ -222,14 +222,14 @@ def patchProfileBasedOnParent(pomModel) {
         return false
     }
 
-    if (parent.artifactId == "booster-parent" && compareVersions(parent.version, "20") < 0) {
-        println "patching maven plugin for booster-parent parent v20"
+    if (parent.artifactId == "booster-parent" && compareVersions(parent.version, "23") < 0) {
+        println "patching maven plugin for booster-parent parent v23"
         addFMPDefinition(pomModel, FMP_STABLE_VERSION)
         return true
     }
 
-    if (parent.artifactId == "spring-boot-booster-parent" && compareVersions(parent.version, "1.5.10-15") < 0) {
-        println "patching maven plugin for spring-boot-booster-parent v1.5.10-15"
+    if (parent.artifactId == "spring-boot-booster-parent") {
+        println "patching maven plugin for spring-boot-booster-parent"
         addFMPDefinition(pomModel, FMP_STABLE_VERSION)
         return true;
     }

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -7,8 +7,8 @@ import org.apache.maven.model.Profile
 
 @Field final String FMP_STABLE_VERSION = "3.5.38"
 
-// First version of FMP to include 'osio' profile
-@Field final String FMP_OSIO_MIN_VERSION = "3.5.40"
+// First version of FMP to include 'osio' profile. Should not be modified.
+@Field final String FMP_OSIO_PROFILE_MIN_VERSION = "3.5.40"
 
 def call(body) {
     // evaluate the body block, and collect configuration into the object
@@ -274,7 +274,7 @@ def hasFMPProfileForOSIO() {
                 def version = line.substring(versionPrefix.length()).trim()
                 if (!version.isEmpty()) {
                     echo "Found fabric8-maven-plugin version ${version}"
-                    return (compareVersions(version, FMP_OSIO_MIN_VERSION) >= 0)
+                    return (compareVersions(version, FMP_OSIO_PROFILE_MIN_VERSION) >= 0)
                 }
             }
         }

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -39,9 +39,13 @@ def call(body) {
 
     def spaceLabelArg = ""
     if (buildName != null && !buildName.isEmpty()) {
-        def spaceLabel = utils.getSpaceLabelFromBuild(buildName)
-        if (!spaceLabel.isEmpty()) {
-            spaceLabelArg = "-Dfabric8.enricher.fmp-space-label.space=${spaceLabel}"
+        try {
+            def spaceLabel = utils.getSpaceLabelFromBuild(buildName)
+            if (!spaceLabel.isEmpty()) {
+                spaceLabelArg = "-Dfabric8.enricher.fmp-space-label.space=${spaceLabel}"
+            }
+        } catch (err) {
+            echo "Failed to read space label due to: ${err}"
         }
     }
 

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -37,12 +37,15 @@ def call(body) {
         echo "Failed to find buildName due to: ${err}"
     }
 
-    def spaceLabel = ""
+    def spaceLabelArg = ""
     if (buildName != null && !buildName.isEmpty()) {
-        spaceLabel = utils.getSpaceLabelFromBuild(buildName)
+        def spaceLabel = utils.getSpaceLabelFromBuild(buildName)
+        if (!spaceLabel.isEmpty()) {
+            spaceLabelArg = "-Dfabric8.enricher.fmp-space-label.space=${spaceLabel}"
+        }
     }
 
-    sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} -Dfabric8.space=\"${spaceLabel}\" -P openshift"
+    sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} ${spaceLabelArg} -P openshift"
 
 
     junitResults(body);

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -29,10 +29,6 @@ def call(body) {
         }
     }
     sh "mvn org.codehaus.mojo:versions-maven-plugin:2.5:set -U -DnewVersion=${config.version}"
-    sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} -P openshift"
-
-
-    junitResults(body);
 
     def buildName = ""
     try {
@@ -40,6 +36,16 @@ def call(body) {
     } catch (err) {
         echo "Failed to find buildName due to: ${err}"
     }
+
+    def spaceLabel = ""
+    if (buildName != null && !buildName.isEmpty()) {
+        spaceLabel = utils.getSpaceLabelFromBuild()
+    }
+
+    sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} -Dfabric8.space=\"${spaceLabel}\" -P openshift"
+
+
+    junitResults(body);
 
     if (buildName != null && !buildName.isEmpty()) {
         def buildUrl = "${env.BUILD_URL}"

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -39,7 +39,7 @@ def call(body) {
 
     def spaceLabel = ""
     if (buildName != null && !buildName.isEmpty()) {
-        spaceLabel = utils.getSpaceLabelFromBuild()
+        spaceLabel = utils.getSpaceLabelFromBuild(buildName)
     }
 
     sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} -Dfabric8.space=\"${spaceLabel}\" -P openshift"


### PR DESCRIPTION
Recently, Spring Boot boosters stopped working with our "Deployments" tab: https://github.com/openshiftio/openshift.io/issues/2360. 

The root cause of the issue is that the Spring Boot boosters moved their fabric8-maven-plugin execution to a new parent project. When creating a new project, the launcher would look for the fabric8-maven-plugin execution in the project's pom and add a label containing the name of the project's space. If fabric8-maven-plugin is missing from the project's pom file, no space label is added to the generated OpenShift resources. There may also be a problem if the project is shared between more than one space, where the launcher would overwrite the previous space name in the FMP configuration.

In search of a more reliable way to set the space name on objects created by our builds, I'd like to propose this PR which leverages information already available in the build. This involves adding a method in Utils to retrieve the space label from the Build object corresponding to the running Jenkins pipeline. This label is then passed as a property to FMP, which boosters (or parents of boosters) can use in their configuration. Such as:
```
 <resources>
   <labels>
     <all>
       <space>${fabric8.space}</space>
     </all>
   </labels>
 </resources>
```