### PR TITLE
Drop support for kubernetes-plugin older than v0.13

### DIFF
--- a/src/io/fabric8/Utils.groovy
+++ b/src/io/fabric8/Utils.groovy
@@ -597,23 +597,4 @@ def getOpenShiftBuildName(){
   return null
 }
 
-def isKubernetesPluginVersion013(){
-    def isNewVersion = false
-
-    try{
-      def object = new org.csanchez.jenkins.plugins.kubernetes.PodAnnotation('dummy','dummy')
-      def objPackage = object.getClass().getPackage()
-      def version = objPackage.getImplementationVersion()
-      // we could be using a custom built jar so remove any -SNAPSHOT from the version
-      def v = version.replaceAll("-SNAPSHOT","");
-
-      if (v >= '0.13') {
-        isNewVersion = true
-      }
-    } catch (err) {
-      echo "caught error when checking which kubernetes-plugin version we are using; defaulting to < 0.13: ${err}"
-    }
-    return isNewVersion
-}
-
 return this

--- a/vars/chunkyTemplate.groovy
+++ b/vars/chunkyTemplate.groovy
@@ -15,61 +15,61 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'jnlp',
-                                    image: "${jnlpImage}",
-                                    args: '${computer.jnlpmac} ${computer.name}',
-                                    workingDir: '/home/jenkins/'),
-                            containerTemplate(
-                                    name: 'chunky',
-                                    image: "${chunkyImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: [
-                                            envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/')
-                                    ])],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                            secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
+    if (utils.isUseOpenShiftS2IForBuilds()) {
+        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'jnlp',
+                                image: "${jnlpImage}",
+                                args: '${computer.jnlpmac} ${computer.name}',
+                                workingDir: '/home/jenkins/'),
+                        containerTemplate(
+                                name: 'chunky',
+                                image: "${chunkyImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: [
+                                        envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/')
+                                ])],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
+                        secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
 
-                body(
+            body(
 
-                )
-            }
-        } else {
-            podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'chunky',
-                                    image: "${chunkyImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    envVars: [
-                                            envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/'),
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
-                                    ])],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
-            ) {
-
-                body(
-
-                )
-            }
+            )
         }
+    } else {
+        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'chunky',
+                                image: "${chunkyImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                envVars: [
+                                        envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/'),
+                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
+                                ])],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
+                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
+        ) {
+
+            body(
+
+            )
+        }
+    }
 }

--- a/vars/chunkyTemplate.groovy
+++ b/vars/chunkyTemplate.groovy
@@ -14,8 +14,7 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
+
         if (utils.isUseOpenShiftS2IForBuilds()) {
             podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
                     containers: [
@@ -73,45 +72,4 @@ def call(Map parameters = [:], body) {
                 )
             }
         }
-    } else {
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                            [name: 'chunky', image: "${chunkyImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                             envVars: [
-                                     [key: 'MAVEN_OPTS', value: '-Duser.home=/root/']]]],
-                    volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                              secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                              secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                              secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                              secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
-
-                body(
-
-                )
-            }
-        } else {
-            podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                    containers: [
-                            //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                            [name: 'chunky', image: "${chunkyImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,
-                             envVars: [
-                                     [key: 'MAVEN_OPTS', value: '-Duser.home=/root/']]]],
-                    volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                              secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                              secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                              secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                              secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                              secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                              hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-                    envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]
-            ) {
-
-                body(
-
-                )
-            }
-        }
-    }
 }

--- a/vars/clientsTemplate.groovy
+++ b/vars/clientsTemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
     def flow = new Fabric8Commands()
 
@@ -14,55 +15,55 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            echo 'Running on openshift so using S2I binary source and Docker strategy'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'jnlp',
-                                    image: "${jnlpImage}",
-                                    args: '${computer.jnlpmac} ${computer.name}',
-                                    workingDir: '/home/jenkins/',
-                                    resourceLimitMemory: '512Mi'),
-                            containerTemplate(
-                                    name: 'clients',
-                                    image: "${clientsImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: [
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')],
-                                    resourceLimitMemory: '512Mi')],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
-                body()
-            }
-        } else {
-            echo 'Mounting docker socket to build docker images'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'clients',
-                                    image: "${clientsImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    privileged: true,
-                                    workingDir: '/home/jenkins/',
-                                    ttyEnabled: true,
-                                    envVars: [
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/'),
-                                            envVar(key: 'DOCKER_API_VERSION', value: '1.23'),
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
-                            )],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]) {
-                body()
-            }
+    if (utils.isUseOpenShiftS2IForBuilds()) {
+        echo 'Running on openshift so using S2I binary source and Docker strategy'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'jnlp',
+                                image: "${jnlpImage}",
+                                args: '${computer.jnlpmac} ${computer.name}',
+                                workingDir: '/home/jenkins/',
+                                resourceLimitMemory: '512Mi'),
+                        containerTemplate(
+                                name: 'clients',
+                                image: "${clientsImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: [
+                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')],
+                                resourceLimitMemory: '512Mi')],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
+            body()
         }
+    } else {
+        echo 'Mounting docker socket to build docker images'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'clients',
+                                image: "${clientsImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                privileged: true,
+                                workingDir: '/home/jenkins/',
+                                ttyEnabled: true,
+                                envVars: [
+                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/'),
+                                        envVar(key: 'DOCKER_API_VERSION', value: '1.23'),
+                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
+                        )],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
+                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]) {
+            body()
+        }
+    }
 }

--- a/vars/deployOpenShiftTemplate.groovy
+++ b/vars/deployOpenShiftTemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
     def flow = new Fabric8Commands()
 
@@ -13,54 +14,54 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-        if (flow.isOpenShift()) {
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'jnlp',
-                                    image: "${jnlpImage}",
-                                    args: '${computer.jnlpmac} ${computer.name}',
-                                    workingDir: '/home/jenkins/'),
-                            containerTemplate(
-                                    name   : 'clients',
-                                    image: "${clientsImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: [
-                                            envVar(key: 'TERM', value: 'dumb'),
-                                            envVar(key: 'KUBECONFIG', value: '/root/home/.oc/cd.conf')]
-                            )],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            secretVolume(secretName: openshiftConfigSecretName, mountPath: '/root/home/.oc')
-                    ]) {
-                body()
-            }
-        } else {
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name   : 'clients',
-                                    image: "${clientsImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: [
-                                            envVar(key: 'TERM', value: 'dumb'),
-                                            envVar(key: 'KUBECONFIG', value: '/root/home/.oc/cd.conf')]
-                            )],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            secretVolume(secretName: openshiftConfigSecretName, mountPath: '/root/home/.oc')
-                    ]) {
-                body()
-            }
+    if (flow.isOpenShift()) {
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'jnlp',
+                                image: "${jnlpImage}",
+                                args: '${computer.jnlpmac} ${computer.name}',
+                                workingDir: '/home/jenkins/'),
+                        containerTemplate(
+                                name: 'clients',
+                                image: "${clientsImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: [
+                                        envVar(key: 'TERM', value: 'dumb'),
+                                        envVar(key: 'KUBECONFIG', value: '/root/home/.oc/cd.conf')]
+                        )],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
+                        secretVolume(secretName: openshiftConfigSecretName, mountPath: '/root/home/.oc')
+                ]) {
+            body()
         }
+    } else {
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'clients',
+                                image: "${clientsImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: [
+                                        envVar(key: 'TERM', value: 'dumb'),
+                                        envVar(key: 'KUBECONFIG', value: '/root/home/.oc/cd.conf')]
+                        )],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
+                        secretVolume(secretName: openshiftConfigSecretName, mountPath: '/root/home/.oc')
+                ]) {
+            body()
+        }
+    }
 }

--- a/vars/deployOpenShiftTemplate.groovy
+++ b/vars/deployOpenShiftTemplate.groovy
@@ -13,8 +13,6 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
         if (flow.isOpenShift()) {
             podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
                     containers: [
@@ -65,36 +63,4 @@ def call(Map parameters = [:], body) {
                 body()
             }
         }
-    } else {
-        if (flow.isOpenShift()) {
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                            [name   : 'clients', image: "${clientsImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                             envVars: [[key: 'TERM', value: 'dumb'],[key: 'KUBECONFIG', value: '/root/home/.oc/cd.conf']]]
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            secretVolume(secretName: openshiftConfigSecretName, mountPath: '/root/home/.oc')
-                    ]) {
-                body()
-            }
-        } else {
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name   : 'clients', image: "${clientsImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                             envVars: [[key: 'TERM', value: 'dumb'],[key: 'KUBECONFIG', value: '/root/home/.oc/cd.conf']]]
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            secretVolume(secretName: openshiftConfigSecretName, mountPath: '/root/home/.oc')
-                    ]) {
-                body()
-            }
-        }
-    }
 }

--- a/vars/deployTemplate.groovy
+++ b/vars/deployTemplate.groovy
@@ -13,8 +13,7 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
+
         podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
                 containers: [
                         containerTemplate(
@@ -44,21 +43,4 @@ def call(Map parameters = [:], body) {
                 ]) {
             body()
         }
-    } else {
-        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                containers: [
-                        //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                        [name   : 'clients', image: "${clientsImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                         envVars: [[key: 'TERM', value: 'dumb']]],
-                        [name   : 'maven', image: "${mavenImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                         envVars: [
-                                 [key: 'MAVEN_OPTS', value: '-Duser.home=/root/']]]
-                ],
-                volumes: [
-                        secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                        secretVolume(secretName: 'gke-service-account', mountPath: '/root/home/.gke')
-                ]) {
-            body()
-        }
-    }
 }

--- a/vars/deployTemplate.groovy
+++ b/vars/deployTemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
     def flow = new Fabric8Commands()
 
@@ -14,33 +15,33 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                containers: [
-                        containerTemplate(
-                                name   : 'clients',
-                                image: "${clientsImage}",
-                                command: '/bin/sh -c',
-                                args: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/',
-                                envVars: [
-                                        envVar(key: 'TERM', value: 'dumb')
-                                ]),
-                        containerTemplate(
-                                name   : 'maven',
-                                image: "${mavenImage}",
-                                command: '/bin/sh -c',
-                                args: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/',
-                                envVars: [
-                                        envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/')
-                                ])
-                ],
-                volumes: [
-                        secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                        secretVolume(secretName: 'gke-service-account', mountPath: '/root/home/.gke')
-                ]) {
-            body()
-        }
+    podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+            containers: [
+                    containerTemplate(
+                            name: 'clients',
+                            image: "${clientsImage}",
+                            command: '/bin/sh -c',
+                            args: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/',
+                            envVars: [
+                                    envVar(key: 'TERM', value: 'dumb')
+                            ]),
+                    containerTemplate(
+                            name: 'maven',
+                            image: "${mavenImage}",
+                            command: '/bin/sh -c',
+                            args: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/',
+                            envVars: [
+                                    envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/')
+                            ])
+            ],
+            volumes: [
+                    secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
+                    secretVolume(secretName: 'gke-service-account', mountPath: '/root/home/.gke')
+            ]) {
+        body()
+    }
 }

--- a/vars/dockerTemplate.groovy
+++ b/vars/dockerTemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
     def flow = new Fabric8Commands()
 
@@ -14,25 +15,25 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                containers: [
-                        containerTemplate(
-                                name: 'docker',
-                                image: "${dockerImage}",
-                                command: '/bin/sh -c',
-                                args: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/',
-                                envVars: [
-                                        envVar(key: 'DOCKER_API_VERSION', value: '1.23'),
-                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
-                                        ]
-                        )],
-                volumes: [
-                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
-        ) {
-            body()
-        }
+    podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+            containers: [
+                    containerTemplate(
+                            name: 'docker',
+                            image: "${dockerImage}",
+                            command: '/bin/sh -c',
+                            args: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/',
+                            envVars: [
+                                    envVar(key: 'DOCKER_API_VERSION', value: '1.23'),
+                                    envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
+                            ]
+                    )],
+            volumes: [
+                    secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                    secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                    hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
+    ) {
+        body()
+    }
 }

--- a/vars/dockerTemplate.groovy
+++ b/vars/dockerTemplate.groovy
@@ -13,8 +13,7 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
+
         podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
                 containers: [
                         containerTemplate(
@@ -36,22 +35,4 @@ def call(Map parameters = [:], body) {
         ) {
             body()
         }
-    } else {
-
-        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                containers: [
-                        //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                        [name: 'docker', image: "${dockerImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                         envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/'],[key: 'DOCKER_API_VERSION', value: '1.23']]]],
-                volumes: [
-                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-                envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/'],[key: 'DOCKER_API_VERSION', value: '1.23']]) {
-
-            body()
-
-        }
-    }
-
 }

--- a/vars/fabric8EETestTemplate.groovy
+++ b/vars/fabric8EETestTemplate.groovy
@@ -28,8 +28,6 @@ def call(Map parameters = [:], body) {
     ]
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
         if (utils.isUseOpenShiftS2IForBuilds()) {
             echo 'Runnning on openshift so using S2I binary source and Docker strategy'
             podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
@@ -82,34 +80,4 @@ def call(Map parameters = [:], body) {
                 body()
             }
         }
-    } else {
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            echo 'Runnning on openshift so using S2I binary source and Docker strategy'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                            [name: 'test', image: "${uiImage}", alwaysPullImage: true, command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/', envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]]],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
-                body()
-            }
-        } else {
-            echo 'Mounting docker socket to build docker images'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'test', image: "${uiImage}", command: '/bin/sh -c', args: 'cat', privileged: true,  workingDir: '/home/jenkins/', ttyEnabled: true, envVars: testEnvVars]],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-                    envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]) {
-                body()
-            }
-        }
-    }
 }

--- a/vars/fabric8EETestTemplate.groovy
+++ b/vars/fabric8EETestTemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
 
     def flow = new Fabric8Commands()
@@ -28,56 +29,56 @@ def call(Map parameters = [:], body) {
     ]
 
     def utils = new io.fabric8.Utils()
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            echo 'Runnning on openshift so using S2I binary source and Docker strategy'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'jnlp',
-                                    image: "${jnlpImage}",
-                                    args: '${computer.jnlpmac} ${computer.name}',
-                                    workingDir: '/home/jenkins/'),
-                            containerTemplate(
-                                    name: 'test',
-                                    image: "${uiImage}",
-                                    alwaysPullImage: true,
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: testEnvVars)
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
-                body()
-            }
-        } else {
-            echo 'Mounting docker socket to build docker images'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'test',
-                                    image: "${uiImage}",
-                                    alwaysPullImage: true,
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    privileged: true,
-                                    workingDir: '/home/jenkins/',
-                                    ttyEnabled: true,
-                                    envVars: testEnvVars)
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]) {
-                body()
-            }
+    if (utils.isUseOpenShiftS2IForBuilds()) {
+        echo 'Runnning on openshift so using S2I binary source and Docker strategy'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'jnlp',
+                                image: "${jnlpImage}",
+                                args: '${computer.jnlpmac} ${computer.name}',
+                                workingDir: '/home/jenkins/'),
+                        containerTemplate(
+                                name: 'test',
+                                image: "${uiImage}",
+                                alwaysPullImage: true,
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: testEnvVars)
+                ],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
+                        secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
+            body()
         }
+    } else {
+        echo 'Mounting docker socket to build docker images'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'test',
+                                image: "${uiImage}",
+                                alwaysPullImage: true,
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                privileged: true,
+                                workingDir: '/home/jenkins/',
+                                ttyEnabled: true,
+                                envVars: testEnvVars)
+                ],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
+                        secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
+                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]) {
+            body()
+        }
+    }
 }

--- a/vars/fabric8UITemplate.groovy
+++ b/vars/fabric8UITemplate.groovy
@@ -21,8 +21,7 @@ def call(Map parameters = [:], body) {
     ]
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
+
         if (utils.isUseOpenShiftS2IForBuilds()) {
             echo 'Runnning on openshift so using S2I binary source and Docker strategy'
             podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
@@ -73,34 +72,5 @@ def call(Map parameters = [:], body) {
                 body()
             }
         }
-    } else {
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            echo 'Runnning on openshift so using S2I binary source and Docker strategy'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                            [name: 'ui', image: "${uiImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/', envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]]],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
-                body()
-            }
-        } else {
-            echo 'Mounting docker socket to build docker images'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'ui', image: "${uiImage}", command: '/bin/sh -c', args: 'cat', privileged: true,  workingDir: '/home/jenkins/', ttyEnabled: true, envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]]],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-                    envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]) {
-                body()
-            }
-        }
-    }
+
 }

--- a/vars/fabric8UITemplate.groovy
+++ b/vars/fabric8UITemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
     def flow = new Fabric8Commands()
 
@@ -22,55 +23,55 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            echo 'Runnning on openshift so using S2I binary source and Docker strategy'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'jnlp',
-                                    image: "${jnlpImage}",
-                                    args: '${computer.jnlpmac} ${computer.name}',
-                                    workingDir: '/home/jenkins/'),
-                            containerTemplate(
-                                    name: 'ui',
-                                    image: "${uiImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: testEnvVars)
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
-                body()
-            }
-        } else {
-            echo 'Mounting docker socket to build docker images'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'ui',
-                                    image: "${uiImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    privileged: true,
-                                    workingDir: '/home/jenkins/',
-                                    ttyEnabled: true,
-                                    envVars: testEnvVars)
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git-ro'),
-                            secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]) {
-                body()
-            }
+    if (utils.isUseOpenShiftS2IForBuilds()) {
+        echo 'Runnning on openshift so using S2I binary source and Docker strategy'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'jnlp',
+                                image: "${jnlpImage}",
+                                args: '${computer.jnlpmac} ${computer.name}',
+                                workingDir: '/home/jenkins/'),
+                        containerTemplate(
+                                name: 'ui',
+                                image: "${uiImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: testEnvVars)
+                ],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
+                        secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
+            body()
         }
+    } else {
+        echo 'Mounting docker socket to build docker images'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'ui',
+                                image: "${uiImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                privileged: true,
+                                workingDir: '/home/jenkins/',
+                                ttyEnabled: true,
+                                envVars: testEnvVars)
+                ],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git-ro'),
+                        secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
+                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]) {
+            body()
+        }
+    }
 
 }

--- a/vars/fabric8UITestTemplate.groovy
+++ b/vars/fabric8UITestTemplate.groovy
@@ -15,54 +15,54 @@ def call(Map parameters = [:], body) {
 
     def cloud = flow.getCloudConfig()
 
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            echo 'Runnning on openshift so using S2I binary source and Docker strategy'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'jnlp',
-                                    image: "${jnlpImage}",
-                                    args: '${computer.jnlpmac} ${computer.name}',
-                                    workingDir: '/home/jenkins/'),
-                            containerTemplate(name: 'ui',
-                                    image: "${uiImage}",command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: [
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
-                                    ]
-                            )
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
-                body()
-            }
-        } else {
-            echo 'Mounting docker socket to build docker images'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate(
-                                    name: 'ui',
-                                    image: "${uiImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    privileged: true,
-                                    workingDir: '/home/jenkins/',
-                                    ttyEnabled: true,
-                                    envVars: [
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
-                                    ]
-                            )
-                    ],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')
-                    ]
-            ) {
-                body()
-            }
+    if (utils.isUseOpenShiftS2IForBuilds()) {
+        echo 'Runnning on openshift so using S2I binary source and Docker strategy'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'jnlp',
+                                image: "${jnlpImage}",
+                                args: '${computer.jnlpmac} ${computer.name}',
+                                workingDir: '/home/jenkins/'),
+                        containerTemplate(name: 'ui',
+                                image: "${uiImage}", command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: [
+                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
+                                ]
+                        )
+                ],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
+            body()
         }
+    } else {
+        echo 'Mounting docker socket to build docker images'
+        podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                name: 'ui',
+                                image: "${uiImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                privileged: true,
+                                workingDir: '/home/jenkins/',
+                                ttyEnabled: true,
+                                envVars: [
+                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
+                                ]
+                        )
+                ],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')
+                ]
+        ) {
+            body()
+        }
+    }
 }

--- a/vars/fabric8UITestTemplate.groovy
+++ b/vars/fabric8UITestTemplate.groovy
@@ -15,8 +15,6 @@ def call(Map parameters = [:], body) {
 
     def cloud = flow.getCloudConfig()
 
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
         if (utils.isUseOpenShiftS2IForBuilds()) {
             echo 'Runnning on openshift so using S2I binary source and Docker strategy'
             podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
@@ -67,34 +65,4 @@ def call(Map parameters = [:], body) {
                 body()
             }
         }
-    } else {
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            echo 'Runnning on openshift so using S2I binary source and Docker strategy'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                            [name: 'ui', image: "${uiImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/', envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]]],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            //secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            //secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken')]) {
-                body()
-            }
-        } else {
-            echo 'Mounting docker socket to build docker images'
-            podTemplate(cloud: cloud, label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                    containers: [
-                            [name: 'ui', image: "${uiImage}", command: '/bin/sh -c', args: 'cat', privileged: true,  workingDir: '/home/jenkins/', ttyEnabled: true, envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]]],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            //secretVolume(secretName: 'npm-npmrc', mountPath: '/home/jenkins/.npm-npmrc'),
-                            //secretVolume(secretName: 'npm-token', mountPath: '/home/jenkins/.npm-token'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-                    envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]) {
-                body()
-            }
-        }
-    }
 }

--- a/vars/goTemplate.groovy
+++ b/vars/goTemplate.groovy
@@ -12,8 +12,6 @@ def call(Map parameters = [:], body) {
     def jnlpImage = (flow.isOpenShift()) ? 'fabric8/jenkins-slave-base-centos7:0.0.1' : 'jenkinsci/jnlp-slave:2.62'
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
         podTemplate(label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
                 containers: [
                         containerTemplate(
@@ -40,24 +38,4 @@ def call(Map parameters = [:], body) {
             body()
 
         }
-    } else {
-        podTemplate(label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                containers: [
-                        //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                        [name: 'go', image: "${goImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                         envVars: [
-                                 [key: 'GOPATH', value: '/home/jenkins/go']
-                         ]],
-                        [name: 'clients', image: "${clientsImage}", command: 'cat', ttyEnabled: true]],
-
-                volumes:
-                        [secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                         secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                         secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')
-                        ]) {
-
-            body()
-
-        }
-    }
 }

--- a/vars/goTemplate.groovy
+++ b/vars/goTemplate.groovy
@@ -12,30 +12,30 @@ def call(Map parameters = [:], body) {
     def jnlpImage = (flow.isOpenShift()) ? 'fabric8/jenkins-slave-base-centos7:0.0.1' : 'jenkinsci/jnlp-slave:2.62'
 
     def utils = new io.fabric8.Utils()
-        podTemplate(label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
-                containers: [
-                        containerTemplate(
-                                name: 'go',
-                                image: "${goImage}",
-                                command: '/bin/sh -c',
-                                args: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/',
-                                envVars: [
-                                        envVar(key: 'GOPATH', value: '/home/jenkins/go')
-                                ]),
-                        containerTemplate(
-                                name: 'clients',
-                                image: "${clientsImage}",
-                                command: 'cat',
-                                ttyEnabled: true)
-                ],
-                volumes:
-                        [secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                         secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                         secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')
-                        ]) {
-            body()
+    podTemplate(label: label, serviceAccount: 'jenkins', inheritFrom: "${inheritFrom}",
+            containers: [
+                    containerTemplate(
+                            name: 'go',
+                            image: "${goImage}",
+                            command: '/bin/sh -c',
+                            args: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/',
+                            envVars: [
+                                    envVar(key: 'GOPATH', value: '/home/jenkins/go')
+                            ]),
+                    containerTemplate(
+                            name: 'clients',
+                            image: "${clientsImage}",
+                            command: 'cat',
+                            ttyEnabled: true)
+            ],
+            volumes:
+                    [secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                     secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                     secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')
+                    ]) {
+        body()
 
-        }
+    }
 }

--- a/vars/mavenTemplate.groovy
+++ b/vars/mavenTemplate.groovy
@@ -16,78 +16,78 @@ def call(Map parameters = [:], body) {
 
     def cloud = flow.getCloudConfig()
 
-        def javaOptions = parameters.get('javaOptions', '-Duser.home=/root/ -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m')
+    def javaOptions = parameters.get('javaOptions', '-Duser.home=/root/ -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m')
 
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            def mavenOpts = parameters.get('mavenOpts', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn')
+    if (utils.isUseOpenShiftS2IForBuilds()) {
+        def mavenOpts = parameters.get('mavenOpts', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn')
 
-            podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}", serviceAccount: 'jenkins',
-                    containers: [
-                            containerTemplate(
-                                    name: 'jnlp',
-                                    image: "${jnlpImage}",
-                                    args: '${computer.jnlpmac} ${computer.name}',
-                                    workingDir: '/home/jenkins/',
-                                    resourceLimitMemory: '256Mi'),
-                            containerTemplate(
-                                    name: 'maven',
-                                    image: "${mavenImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    workingDir: '/home/jenkins/',
-                                    envVars: [
-                                            envVar(key: '_JAVA_OPTIONS', value: javaOptions),
-                                            envVar(key: 'MAVEN_OPTS', value: mavenOpts)
-                                            ],
-                                    resourceLimitMemory: '640Mi')],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                            secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
+        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}", serviceAccount: 'jenkins',
+                containers: [
+                        containerTemplate(
+                                name: 'jnlp',
+                                image: "${jnlpImage}",
+                                args: '${computer.jnlpmac} ${computer.name}',
+                                workingDir: '/home/jenkins/',
+                                resourceLimitMemory: '256Mi'),
+                        containerTemplate(
+                                name: 'maven',
+                                image: "${mavenImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                workingDir: '/home/jenkins/',
+                                envVars: [
+                                        envVar(key: '_JAVA_OPTIONS', value: javaOptions),
+                                        envVar(key: 'MAVEN_OPTS', value: mavenOpts)
+                                ],
+                                resourceLimitMemory: '640Mi')],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
+                        secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
 
-                body(
+            body(
 
-                )
-            }
-        } else {
-            echo "building using the docker socket"
-
-            def mavenOpts = parameters.get('mavenOpts', '-Duser.home=/root/ -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn')
-
-            podTemplate(cloud: cloud,
-                    label: label,
-                    inheritFrom: "${inheritFrom}",
-                    containers: [
-                            containerTemplate (
-                                    //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}'],
-                                    name: 'maven',
-                                    image: "${mavenImage}",
-                                    command: '/bin/sh -c',
-                                    args: 'cat',
-                                    ttyEnabled: true,
-                                    alwaysPullImage: false,
-                                    workingDir: '/home/jenkins/',
-                                    //resourceLimitMemory: '640Mi',
-                                    envVars: [
-                                            envVar(key: '_JAVA_OPTIONS', value: javaOptions),
-                                            envVar(key: 'MAVEN_OPTS', value: mavenOpts),
-                                            envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')])],
-                    volumes: [
-                            secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                            secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                            secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                            secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                            secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                            secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                            hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')])
-                    {
-
-                        body(
-
-                        )
-                    }
+            )
         }
+    } else {
+        echo "building using the docker socket"
+
+        def mavenOpts = parameters.get('mavenOpts', '-Duser.home=/root/ -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn')
+
+        podTemplate(cloud: cloud,
+                label: label,
+                inheritFrom: "${inheritFrom}",
+                containers: [
+                        containerTemplate(
+                                //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}'],
+                                name: 'maven',
+                                image: "${mavenImage}",
+                                command: '/bin/sh -c',
+                                args: 'cat',
+                                ttyEnabled: true,
+                                alwaysPullImage: false,
+                                workingDir: '/home/jenkins/',
+                                //resourceLimitMemory: '640Mi',
+                                envVars: [
+                                        envVar(key: '_JAVA_OPTIONS', value: javaOptions),
+                                        envVar(key: 'MAVEN_OPTS', value: mavenOpts),
+                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')])],
+                volumes: [
+                        secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
+                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                        secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
+                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
+                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')])
+                {
+
+                    body(
+
+                    )
+                }
+    }
 }

--- a/vars/mavenTemplate.groovy
+++ b/vars/mavenTemplate.groovy
@@ -16,10 +16,6 @@ def call(Map parameters = [:], body) {
 
     def cloud = flow.getCloudConfig()
 
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
-        echo "Kubernetes Plugin Version 013"
-
         def javaOptions = parameters.get('javaOptions', '-Duser.home=/root/ -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xms10m -Xmx192m')
 
         if (utils.isUseOpenShiftS2IForBuilds()) {
@@ -94,57 +90,4 @@ def call(Map parameters = [:], body) {
                         )
                     }
         }
-    } else {
-        if (utils.isUseOpenShiftS2IForBuilds()) {
-            def javaOptions = parameters.get('javaOptions', '-Duser.home=/root/ -XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xmx256m')
-            def mavenOpts = parameters.get('mavenOpts', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn')
-
-            podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}", serviceAccount: 'jenkins', restartPolicy: 'OnFailure',
-                    containers: [
-                            [name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}', workingDir: '/home/jenkins/',
-                             resourceLimitMemory: '512Mi'], // needs to be high to work on OSO
-                            [name: 'maven', image: "${mavenImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true, workingDir: '/home/jenkins/',
-                             envVars: [
-                                     [key: '_JAVA_OPTIONS', value: javaOptions],
-                                     [key: 'MAVEN_OPTS', value: mavenOpts]
-                                     ],
-                             resourceLimitMemory: '1024Mi']],
-                    volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                              secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                              secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                              secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                              secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')],
-                    envVars: [[key: 'GIT_COMMITTER_EMAIL', value: 'fabric8@googlegroups.com'], [key: 'GIT_COMMITTER_NAME', value: 'fabric8']]) {
-
-                body(
-
-                )
-            }
-        } else {
-            echo "building using the docker socket"
-
-            def mavenOpts = parameters.get('mavenOpts', '-Duser.home=/root/ -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn')
-
-            podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                    containers: [
-                            //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}'],
-                            [name: 'maven', image: "${mavenImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,
-                             envVars: [
-                                     [key: 'MAVEN_OPTS', value: mavenOpts]]]],
-                    volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                              secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                              secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                              secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                              secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                              secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                              hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-                    envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]
-            ) {
-
-                body(
-
-                )
-            }
-        }
-    }
 }

--- a/vars/nodejsTemplate.groovy
+++ b/vars/nodejsTemplate.groovy
@@ -13,8 +13,7 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
+
         podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
                 containers: [
                         containerTemplate(
@@ -28,13 +27,4 @@ def call(Map parameters = [:], body) {
         ) {
             body()
         }
-    } else {
-        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                containers: [
-                        //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                        [name: 'nodejs', image: "${nodejsImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/']]) {
-            body()
-        }
-    }
-
 }

--- a/vars/nodejsTemplate.groovy
+++ b/vars/nodejsTemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
     def flow = new Fabric8Commands()
 
@@ -14,17 +15,17 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                containers: [
-                        containerTemplate(
-                                name: 'nodejs',
-                                image: "${nodejsImage}",
-                                command: '/bin/sh -c',
-                                args: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/')
-                ]
-        ) {
-            body()
-        }
+    podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
+            containers: [
+                    containerTemplate(
+                            name: 'nodejs',
+                            image: "${nodejsImage}",
+                            command: '/bin/sh -c',
+                            args: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/')
+            ]
+    ) {
+        body()
+    }
 }

--- a/vars/releaseTemplate.groovy
+++ b/vars/releaseTemplate.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/groovy
 import io.fabric8.Fabric8Commands
+
 def call(Map parameters = [:], body) {
     def flow = new Fabric8Commands()
 
@@ -15,48 +16,48 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                containers: [
-                        containerTemplate(
-                                name: 'maven',
-                                image: "${mavenImage}",
-                                command: 'cat',
-                                ttyEnabled: true,
-                                envVars: [
-                                        envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/')
-                                ]
-                        ),
-                        containerTemplate(
-                                name   : 'clients',
-                                image: "${clientsImage}",
-                                command: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/',
-                                envVars: [
-                                        envVar(key: 'TERM', value: 'dumb')
-                                ]),
-                        containerTemplate(
-                                name: 'docker',
-                                image: "${dockerImage}",
-                                command: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/',
-                                envVars: [
-                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
-                                ])
-                ],
-                volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                          secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                          secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                          secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                          secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                          secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                          secretVolume(secretName: 'gke-service-account', mountPath: '/root/home/.gke'),
-                          hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
-        ) {
+    podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
+            containers: [
+                    containerTemplate(
+                            name: 'maven',
+                            image: "${mavenImage}",
+                            command: 'cat',
+                            ttyEnabled: true,
+                            envVars: [
+                                    envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/')
+                            ]
+                    ),
+                    containerTemplate(
+                            name: 'clients',
+                            image: "${clientsImage}",
+                            command: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/',
+                            envVars: [
+                                    envVar(key: 'TERM', value: 'dumb')
+                            ]),
+                    containerTemplate(
+                            name: 'docker',
+                            image: "${dockerImage}",
+                            command: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/',
+                            envVars: [
+                                    envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')
+                            ])
+            ],
+            volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
+                      secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                      secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
+                      secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                      secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                      secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
+                      secretVolume(secretName: 'gke-service-account', mountPath: '/root/home/.gke'),
+                      hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')]
+    ) {
 
-            body(
+        body(
 
-            )
-        }
+        )
+    }
 }

--- a/vars/releaseTemplate.groovy
+++ b/vars/releaseTemplate.groovy
@@ -14,8 +14,7 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
+
         podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
                 containers: [
                         containerTemplate(
@@ -60,34 +59,4 @@ def call(Map parameters = [:], body) {
 
             )
         }
-    } else {
-        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                containers: [
-                        //[name: 'jnlp', image: "${jnlpImage}", args: '${computer.jnlpmac} ${computer.name}',  workingDir: '/home/jenkins/'],
-                        [name: 'maven', image: "${mavenImage}", command: 'cat', ttyEnabled: true,
-                         envVars: [[key: 'MAVEN_OPTS', value: '-Duser.home=/root/']]],
-
-                        [name   : 'clients', image: "${clientsImage}", command: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                         envVars: [[key: 'TERM', value: 'dumb']]],
-
-                        [name: 'docker', image: "${dockerImage}", command: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                         envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]]
-                ],
-                volumes: [secretVolume(secretName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
-                          secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                          secretVolume(secretName: 'jenkins-release-gpg', mountPath: '/home/jenkins/.gnupg'),
-                          secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                          secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                          secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git'),
-                          secretVolume(secretName: 'gke-service-account', mountPath: '/root/home/.gke'),
-                          hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-                envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]
-        ) {
-
-            body(
-
-            )
-        }
-    }
-
 }

--- a/vars/s2iTemplate.groovy
+++ b/vars/s2iTemplate.groovy
@@ -17,25 +17,25 @@ def call(Map parameters = [:], body) {
 
     def utils = new io.fabric8.Utils()
 
-        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                containers: [
-                        containerTemplate(
-                                name: 's2i',
-                                image: "${s2iImage}",
-                                command: '/bin/sh -c',
-                                args: 'cat',
-                                ttyEnabled: true,
-                                workingDir: '/home/jenkins/',
-                                envVars: [
-                                        envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
-                        )
-                ],
-                volumes: [
-                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock'),
-                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
-            body()
-        }
+    podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
+            containers: [
+                    containerTemplate(
+                            name: 's2i',
+                            image: "${s2iImage}",
+                            command: '/bin/sh -c',
+                            args: 'cat',
+                            ttyEnabled: true,
+                            workingDir: '/home/jenkins/',
+                            envVars: [
+                                    envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
+                    )
+            ],
+            volumes: [
+                    secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
+                    hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock'),
+                    secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
+                    secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
+                    secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
+        body()
+    }
 }

--- a/vars/s2iTemplate.groovy
+++ b/vars/s2iTemplate.groovy
@@ -16,8 +16,7 @@ def call(Map parameters = [:], body) {
     def cloud = flow.getCloudConfig()
 
     def utils = new io.fabric8.Utils()
-    // 0.13 introduces a breaking change when defining pod env vars so check version before creating build pod
-    if (utils.isKubernetesPluginVersion013()) {
+
         podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
                 containers: [
                         containerTemplate(
@@ -39,19 +38,4 @@ def call(Map parameters = [:], body) {
                         secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
             body()
         }
-    } else {
-        podTemplate(cloud: cloud, label: label, inheritFrom: "${inheritFrom}",
-                containers: [
-
-                        [name: 's2i', image: "${s2iImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/',
-                         envVars: [[key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]]],
-                volumes: [
-                        secretVolume(secretName: 'jenkins-docker-cfg', mountPath: '/home/jenkins/.docker'),
-                        hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock'),
-                        secretVolume(secretName: 'jenkins-ssh-config', mountPath: '/root/.ssh'),
-                        secretVolume(secretName: 'jenkins-hub-api-token', mountPath: '/home/jenkins/.apitoken'),
-                        secretVolume(secretName: 'jenkins-git-ssh', mountPath: '/root/.ssh-git')]) {
-            body()
-        }
-    }
 }


### PR DESCRIPTION
The latest version we are dropping support for is v0.12[1], which was released
on Jul 29, 2017 and there are 431 commits to master since this tag as of now.

Fixes https://github.com/openshiftio/openshift.io/issues/2854

This patch deletes more than 400 lines of code and that is about 8% of the
current code :tada::tada:

1: https://github.com/jenkinsci/kubernetes-plugin/releases/tag/kubernetes-0.12