### PR TITLE
Fixes related to content repository removal

### DIFF
--- a/vars/mavenCI.groovy
+++ b/vars/mavenCI.groovy
@@ -33,7 +33,7 @@ def call(body) {
         stage('Build + Unit test') {
             // set a unique temp version so we can download artifacts from nexus and run acceptance tests
             sh "mvn -U versions:set -DnewVersion=${version}"
-            sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} -P openshift"
+            sh "mvn clean -B -e -U install -Dmaven.test.skip=${skipTests} -P openshift"
         }
 
         def s2iMode = utils.supportsOpenShiftS2I()


### PR DESCRIPTION
Previous PR#409 has changed the CD flow, however, missed changes for CI flow.
This patch fixes the CI flow by updating maven commands that prevent interaction
with the content repository.

Fixes https://github.com/openshiftio/openshift.io/issues/3895
Related PR https://github.com/fabric8io/fabric8-pipeline-library/pull/409