### PR TITLE
fixes deploy goal for maven canary release

### DIFF
--- a/vars/mavenCI.groovy
+++ b/vars/mavenCI.groovy
@@ -33,7 +33,7 @@ def call(body) {
         stage('Build + Unit test') {
             // set a unique temp version so we can download artifacts from nexus and run acceptance tests
             sh "mvn -U versions:set -DnewVersion=${version}"
-            sh "mvn clean -B -e -U install -Dmaven.test.skip=${skipTests} -P openshift"
+            sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} -P openshift"
         }
 
         def s2iMode = utils.supportsOpenShiftS2I()

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -55,7 +55,7 @@ def call(body) {
         }
     }
 
-    sh "mvn clean -B -e -U install -Dmaven.test.skip=${skipTests} ${spaceLabelArg} -P openshift"
+    sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} ${spaceLabelArg} -P openshift"
 
 
     junitResults(body);


### PR DESCRIPTION
With respect to removal of content repository issue
https://github.com/openshiftio/openshift.io/issues/3895
maven canary release target has changed from deploy to install
which is breaking other workflows in the fabric8 CD.
This patch fixes the issue by reverting maven target to deploy.

Fixes https://github.com/openshiftio/openshift.io/issues/4151
