### PR TITLE
CI/Release: Allow overriding mvn goal and profile

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -166,13 +166,35 @@ __WARNING this function is deprecated.  Please change to use getDeploymentResour
 
 - creates a release branch
 - sets the maven pom versions using versions-maven-plugin
+  - version can be overridden as follows
+  ```groovy
+      mavenCanaryRelease{
+        version = canaryVersion
+      }
+  ```
 - runs `mvn deploy docker:build`
-- generates maven site and deploys it to the content repository
+
+- default `goal` of `"install"` can overridden
 ```groovy
     mavenCanaryRelease{
-      version = canaryVersion
+      goal = "deploy"     # executes `mvn deploy` instead of `mvn install`
     }
 ```
+- default `profile` - `"openshift"` can overridden
+```groovy
+    mavenCanaryRelease{
+      profile = "osio"    # executes `mvn install -P osio`
+    }
+```
+
+- mvn cmd can be overriden by setting `cmd` variable.
+```groovy
+    mavenCanaryRelease{
+      cmd = "mvn clean -B -e -U deploy -Dmaven.test.skip=true -P profile"
+    }
+```
+NOTE:  if `cmd` is set, `goal`, `profile`, `skipTests` will have no effect.
+
 - auto updates fabric8 maven plugin in applications `pom.xml`; `true` by default.
 ```groovy
     mavenCanaryRelease{

--- a/vars/mavenCI.groovy
+++ b/vars/mavenCI.groovy
@@ -26,14 +26,17 @@ def call(body) {
             flow.searchAndReplaceMavenVersionProperty(v.key, v.value)
         }
 
+        def goal = config.goal ?: "install"
+        def profile = config.profile ?: "openshift"
         def skipTests = config.skipTests ?: false
+        def cmd = config.cmd ?: "mvn clean -B -e -U ${goal} -Dmaven.test.skip=${skipTests} -P ${profile}"
 
         def version = 'PR-' + getNewVersion {} + "-${env.BUILD_NUMBER}"
 
         stage('Build + Unit test') {
             // set a unique temp version so we can download artifacts from nexus and run acceptance tests
             sh "mvn -U versions:set -DnewVersion=${version}"
-            sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} -P openshift"
+            sh cmd
         }
 
         def s2iMode = utils.supportsOpenShiftS2I()

--- a/vars/mavenCanaryRelease.groovy
+++ b/vars/mavenCanaryRelease.groovy
@@ -55,7 +55,11 @@ def call(body) {
         }
     }
 
-    sh "mvn clean -B -e -U deploy -Dmaven.test.skip=${skipTests} ${spaceLabelArg} -P openshift"
+
+    profile = config.profile ?: "openshift"
+    goal = config.goal ?: "install"
+    cmd = config.cmd ?: "mvn clean -B -e -U ${goal} -Dmaven.test.skip=${skipTests} ${spaceLabelArg} -P ${profile}"
+    sh cmd
 
 
     junitResults(body);


### PR DESCRIPTION
This patch allows the `mvn` goal and profile of the mavenCI and
mavenCanaryRelease steps to be overridden. User can override the
entire command by setting the `cmd` variable or the goal and the
profile by setting `goal` and `profile` respectively.

See ReadMe.md for details

Related to: https://github.com/openshiftio/openshift.io/issues/4151