### PR TITLE
Add new config api to store global pipeline configuration

### DIFF
--- a/src/io/openshift/Globals.groovy
+++ b/src/io/openshift/Globals.groovy
@@ -1,0 +1,6 @@
+package io.openshift
+
+class Globals implements Serializable {
+ // used by vars/config to store all parameters passed into config
+ static config = [:]
+}

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -7,11 +7,12 @@ import groovy.json.*
 def call(Map args) {
     stage("Build application") {
         Events.emit("build.start")
-        def status = ""
         def namespace = args.namespace ?: new Utils().getUsersNamespace()
+        def image = config.runtime() ?: 'oc'
 
+        def status = ""
         try {
-          spawn(image: "oc") {
+          spawn(image: image) {
             createImageStream(args.app.ImageStream, namespace)
             buildProject(args.app.BuildConfig, namespace)
           }

--- a/vars/config.groovy
+++ b/vars/config.groovy
@@ -1,0 +1,14 @@
+import io.openshift.Globals
+
+def call(conf = [:]) {
+  Globals.config << conf // merge
+}
+
+// usage: config.runtime()
+def runtime() {
+  return Globals.config.runtime
+}
+
+def values() {
+  return Globals.config
+}


### PR DESCRIPTION
The config api stores global settings of a pipeline. The initial
version adds support for accessing `runtime` parameter which is now
used in `build` to spawn the container that has the build tools.

e.g setting `config runtime: 'node'`, build and deploy will use
the `node` container instead of the default `oc`